### PR TITLE
run migration for generate simple_blog:install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,10 @@ SimpleBlog works with Rails 4.0 onwards. You can add it to your Gemfile with:
 gem 'simple_blog', :git => 'git@github.com:mixandgo/simple_blog.git'
 ```
 
-#### Post installation
-
-Install migrations
+#### Installation
 
 ```shell
-#For simple blog migrations
-rake simple_blog_engine:install:migrations
-
-#For simple blog tags migrations
-rake acts_as_taggable_on_engine:install:migrations
-```
-
-Install assets
-
-```shell
+#installs assets and run migrations
 rails generate simple_blog:install
 ```
 

--- a/lib/generators/simple_blog/install/install_generator.rb
+++ b/lib/generators/simple_blog/install/install_generator.rb
@@ -28,6 +28,11 @@ module SimpleBlog
         install_libraries(folder, file, text)
       end
 
+      def run_migrations
+        rake "simple_blog_engine:install:migrations"
+        rake "acts_as_taggable_on_engine:install:migrations"
+      end
+
       private
 
       def install_libraries(folder, file, text)

--- a/spec/lib/generators/simple_blog/install/install_generator_spec.rb
+++ b/spec/lib/generators/simple_blog/install/install_generator_spec.rb
@@ -5,27 +5,29 @@ require "generators/simple_blog/install/install_generator"
 
 describe SimpleBlog::Generators::InstallGenerator do
   include GeneratorSpec::TestCase
-  destination File.expand_path("../../../../../tmp", __FILE__)
+
+  let(:generator) { SimpleBlog::Generators::InstallGenerator.new }
 
   before :each do
-    prepare_destination
-  end
-
-  after :each do
-    FileUtils.rm_rf("spec/tmp")
+    allow(generator).to receive(:rake).with("simple_blog_engine:install:migrations")
+    allow(generator).to receive(:rake).with("acts_as_taggable_on_engine:install:migrations")
   end
 
   describe "#install_public_javascript" do
 
+    after :each do
+      File.delete("app/assets/javascripts/application.js")
+    end
+
     it "creates the file and appends 'simple_blog' when file not present" do
-      run_generator
+      generator.install_public_javascript
       assert_file "app/assets/javascripts/application.js", "\n//= require simple_blog\n"
     end
 
     it "appends 'simple_blog' to application.js when file is present" do
-      FileUtils.mkdir_p("spec/tmp/app/assets/javascripts/")
-      File.open("spec/tmp/app/assets/javascripts/application.js", "w")
-      run_generator
+      FileUtils.mkdir_p("app/assets/javascripts/")
+      File.open("app/assets/javascripts/application.js", "w")
+      generator.install_public_javascript
       assert_file "app/assets/javascripts/application.js", "\n//= require simple_blog\n"
     end
 
@@ -33,15 +35,19 @@ describe SimpleBlog::Generators::InstallGenerator do
 
   describe "#install_admin_javascript" do
 
+    after :each do
+      File.delete("app/assets/javascripts/admin.js")
+    end
+
     it "creates the file and appends 'simple_blog_admin' when file not present" do
-      run_generator
+      generator.install_admin_javascript
       assert_file "app/assets/javascripts/admin.js", "\n//= require simple_blog_admin\n"
     end
 
     it "appends 'simple_blog' to admin.js when file is present" do
-      FileUtils.mkdir_p("spec/tmp/app/assets/javascripts/")
-      File.open("spec/tmp/app/assets/javascripts/admin.js", "w")
-      run_generator
+      FileUtils.mkdir_p("app/assets/javascripts/")
+      File.open("app/assets/javascripts/admin.js", "w")
+      generator.install_admin_javascript
       assert_file "app/assets/javascripts/admin.js", "\n//= require simple_blog_admin\n"
     end
 
@@ -49,18 +55,44 @@ describe SimpleBlog::Generators::InstallGenerator do
 
   describe "#install_css_file" do
 
+    after :each do
+      File.delete("app/assets/stylesheets/application.css")
+    end
+
     it "does not create application.css if not already present" do
-      run_generator
+      generator.install_css_file
       assert_file "app/assets/stylesheets/application.css", "\n *= require simple_blog_admin\n"
     end
 
     it "appends 'simple_blog_admin' to application.css when file is present" do
-      FileUtils.mkdir_p("spec/tmp/app/assets/stylesheets/")
-      File.open("spec/tmp/app/assets/stylesheets/application.css", "w")
-      run_generator
+      FileUtils.mkdir_p("app/assets/stylesheets/")
+      File.open("app/assets/stylesheets/application.css", "w")
+      generator.install_css_file
       assert_file "app/assets/stylesheets/application.css", "\n *= require simple_blog_admin\n"
     end
 
   end
 
+  describe "#run_migrations" do
+
+    let(:generator) { SimpleBlog::Generators::InstallGenerator.new }
+    
+    before :each do
+      allow(generator).to receive(:rake).with("simple_blog_engine:install:migrations")
+      allow(generator).to receive(:rake).with("acts_as_taggable_on_engine:install:migrations")
+    end
+
+    it "runs the simple_blog_engine migrations" do
+      expect(generator).to receive(:rake).with("simple_blog_engine:install:migrations")
+
+      generator.run_migrations
+    end
+
+    it "runs the acts_as_taggable_on_engine migrations" do
+      expect(generator).to receive(:rake).with("acts_as_taggable_on_engine:install:migrations")
+
+      generator.run_migrations
+    end
+
+  end
 end


### PR DESCRIPTION
updated README to reflect the new installation
updated the "generate simple_blog:install" command to run the migration after the assets
also updated the specs for the generator
