### PR TITLE
Fix top keyword parser

### DIFF
--- a/app/assets/javascripts/simple_blog_admin/popular_keywords.js
+++ b/app/assets/javascripts/simple_blog_admin/popular_keywords.js
@@ -27,7 +27,7 @@ var KeywordParser = (function () {
   var getAllKeywords = function(html) {
     // strip html tags
     // ignore everything except letters
-    return html.replace(/<\/?[^>]+(>|$)/g, "").replace(/[^a-zA-Z ]/g, "").match(/\S+/g);
+    return html.replace(/<\/?[^>]+(>|$)|(&gt;)|(?:&nbsp;|<br>)|(\s?&lt;)/g, "").replace(/[^a-zA-Z ]/g, "").match(/\S+/g);
   };
 
   var sortKeywords = function() {

--- a/spec/features/create_posts_spec.rb
+++ b/spec/features/create_posts_spec.rb
@@ -62,6 +62,13 @@ feature 'Create posts' do
     expect(page).to have_content('kw: coolbody - nr: 6')
   end
 
+  scenario 'user does not see whitespaces as top keywords when writing an article', :js => true do
+    visit new_admin_blog_post_path
+    wait_for_ckeditor('#cke_simple-blog-post-form-body')
+    fill_in_ckeditor 'simple-blog-post-form-body', :with => "coolbody                        "*6
+    expect(page).to have_content('kw: coolbody - nr: 6')
+  end
+
   scenario 'user can set a published_at date that will stay' do
     create_a_blog_post(:title => "Blog Post Title", :published_at => "01/01/2014")
     visit admin_blog_posts_path


### PR DESCRIPTION
The top keyword parser regex wasn't stripping everything. When adding multiple spaces & nbsp ;
was counted as well
