### PR TITLE
fix empty blog_images

### DIFF
--- a/app/controllers/admin/blog_posts_controller.rb
+++ b/app/controllers/admin/blog_posts_controller.rb
@@ -23,7 +23,7 @@ class Admin::BlogPostsController < Admin::BaseController
   end
 
   def edit
-    @blog_images = @blog_post.images
+    @blog_images = @blog_post.images.all
   end
 
   def update

--- a/spec/controllers/admin/blog_posts_controller_spec.rb
+++ b/spec/controllers/admin/blog_posts_controller_spec.rb
@@ -100,20 +100,20 @@ module Admin
     describe "#edit" do
       let(:id) { "100" }
       let(:post) { double.as_null_object }
-      let(:blog_images) { double.as_null_object }
+      let(:images) { double.as_null_object }
 
       before :each do
         allow(BlogPost).to receive(:unscoped_find_by!).with(:id => id).and_return post
-        allow(post).to receive(:images).and_return blog_images
+        allow(post).to receive(:images).and_return images
       end
 
       it "assigns the @blog_images" do
         get :edit, :id => id
-        expect(assigns(:blog_images)).to eq(blog_images)
+        expect(assigns(:blog_images)).to eq(images)
       end
 
       it "gets all the blog_images" do
-        allow(post).to receive(:images)
+        expect(images).to receive(:all)
         get :edit, :id => id
       end
 


### PR DESCRIPTION
without the all from blog_post.images.all there would always be an empty Delete Image link in the edit page
