### PR TITLE
change what happens on successful create

### DIFF
--- a/app/controllers/admin/blog_posts_controller.rb
+++ b/app/controllers/admin/blog_posts_controller.rb
@@ -15,7 +15,7 @@ class Admin::BlogPostsController < Admin::BaseController
     @blog_post = BlogPost.new(blog_post_params)
     if @blog_post.save
       flash[:notice] = t('.flash_notice')
-      redirect_to admin_blog_posts_path
+      redirect_to edit_admin_blog_post_path(@blog_post.id)
     else
       flash[:alert] = t('.flash_alert')
       render :action => :new

--- a/spec/controllers/admin/blog_posts_controller_spec.rb
+++ b/spec/controllers/admin/blog_posts_controller_spec.rb
@@ -27,7 +27,7 @@ module Admin
 
         it "redirects to the index page" do
           post :create, :blog_post => params
-          expect(response).to redirect_to(admin_blog_posts_path)
+          expect(response).to redirect_to(edit_admin_blog_post_path(blog_post.id))
         end
 
         it "sets a flash notice" do

--- a/spec/features/create_posts_spec.rb
+++ b/spec/features/create_posts_spec.rb
@@ -42,6 +42,7 @@ feature 'Create posts' do
 
   scenario 'user can delete a post' do
     create_a_blog_post(:title => "Blog Post Title")
+    visit admin_blog_posts_path
     click_on "Delete"
     expect(page).to have_content('Post was deleted succesfully')
     expect(page).to have_content('There are no published posts available.')
@@ -71,8 +72,6 @@ feature 'Create posts' do
 
   scenario 'user can set a published_at date that will stay' do
     create_a_blog_post(:title => "Blog Post Title", :published_at => "01/01/2014")
-    visit admin_blog_posts_path
-    click_on 'Blog Post Title'
     expect(page).to have_xpath("//input[@value='01/01/2014']")
   end
 

--- a/spec/features/edit_posts_spec.rb
+++ b/spec/features/edit_posts_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 feature 'Edit posts' do
   scenario 'editting a post' do
     create_a_blog_post(:title => 'Blog Post Title')
-    visit_admin_edit_page_for('Blog Post Title')
     fill_in 'simple-blog-post-form-title', :with => 'Different Blog Post Title'
     click_on 'Update post'
     expect(page).to have_content('Different Blog Post Title')
@@ -12,7 +11,6 @@ feature 'Edit posts' do
 
   scenario 'handle validations' do
     create_a_blog_post(:title => 'Blog Post Title')
-    visit_admin_edit_page_for('Blog Post Title')
     invalid_title = "a" * 80 # triggers a validation error
     invalid_body = invalid_description = ""
     fill_in 'simple-blog-post-form-title', :with => invalid_title
@@ -27,7 +25,6 @@ feature 'Edit posts' do
 
   scenario 'update tags' do
     create_a_blog_post(:title => 'Blog Post Title')
-    visit_admin_edit_page_for('Blog Post Title')
     fill_in 'simple-blog-post-form-tag-list', :with => 'Edited_tag'
     click_on 'Update post'
     visit admin_blog_posts_path
@@ -36,7 +33,6 @@ feature 'Edit posts' do
 
   scenario 'update keywords' do
     create_a_blog_post(:title => 'Blog Post Title')
-    visit_admin_edit_page_for('Blog Post Title')
     fill_in 'simple-blog-post-form-keyword-list', :with => 'edited_keyword1, edited_keyword2'
     click_on 'Update post'
     visit admin_blog_posts_path
@@ -45,7 +41,6 @@ feature 'Edit posts' do
 
   scenario 'deleting a post' do
     create_a_blog_post(:title => 'Blog Post Title')
-    click_on 'Blog Post Title'
     click_on 'Delete post'
     expect(page).to have_content('Post was deleted succesfully')
     expect(page).to have_content('There are no published posts available.')
@@ -53,13 +48,11 @@ feature 'Edit posts' do
 
   scenario 'previewing a blog_post' do
     create_a_blog_post(:title => 'Blog Post Title', :unpublished => true)
-    click_on 'Blog Post Title'
     expect(page).to have_link("Preview: Blog Post Title", :href => "/blog/blog-post-title")
   end
 
   scenario 'clicking on the preview link will show me the blog post' do
     create_a_blog_post(:title => 'Blog Post Title', :unpublished => true)
-    click_on 'Blog Post Title'
     click_on 'Preview: Blog Post Title'
     expect(page).to have_content('Blog Post Title')
   end


### PR DESCRIPTION
changed the logic so that after you create a blog posts it stays on the edit page. before it redirected to the admin page but that is a pain in the ass when you want to use the preview functionality
