### PR TITLE
prevent duplicate articles by filtering

### DIFF
--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -7,7 +7,7 @@ class BlogPostsController < ApplicationController
   end
 
   def filter
-    @blog_posts = BlogPost.tagged_with(blog_post_params[:tag])
+    @blog_posts = BlogPost.tagged_with(blog_post_params[:tag], :on => :tags)
     render :index
   end
 

--- a/spec/controllers/blog_posts_controller_spec.rb
+++ b/spec/controllers/blog_posts_controller_spec.rb
@@ -29,11 +29,11 @@ describe BlogPostsController, :type => :controller do
     let(:blog_post) { double("BlogPost") }
 
     before :each do
-      allow(BlogPost).to receive(:tagged_with).with(tag).and_return [blog_post]
+      allow(BlogPost).to receive(:tagged_with).with(tag, :on => :tags).and_return([blog_post])
     end
 
     it "finds all blog posts filtered by tag" do
-      expect(BlogPost).to receive(:tagged_with).with(tag)
+      expect(BlogPost).to receive(:tagged_with).with(tag, :on => :tags)
       get :filter, :tag => tag
     end
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.
@@ -33,4 +33,5 @@ Dummy::Application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+  config.active_record.raise_in_transactional_callbacks = true
 end

--- a/spec/features/list_posts_spec.rb
+++ b/spec/features/list_posts_spec.rb
@@ -34,4 +34,12 @@ feature 'List posts' do
     expect(page).to have_content('Blog Post Title')
     expect(page).not_to have_content('Different Tag Blog Post Title')
   end
+
+  scenario "filtering by tag shouldn't filter by keyword" do
+    create_a_blog_post(:title => 'Differnt tag blog post title', :keywords => 'first_tag')
+    visit blog_posts_path
+    click_link('first_tag', :match => :first)
+    expect(page).to have_content('Blog Post Title')
+    expect(page).not_to have_content('Different Tag Blog Post Title')
+  end
 end


### PR DESCRIPTION
You can specify what to filter_with. I've changed the controller to only filter by tags. This should prevent the duplicate articles. 