### PR TITLE
Feature/63 language attribute

### DIFF
--- a/app/controllers/admin/blog_posts_controller.rb
+++ b/app/controllers/admin/blog_posts_controller.rb
@@ -54,7 +54,7 @@ class Admin::BlogPostsController < Admin::BaseController
     end
 
     def blog_post_params
-      params.require(:blog_post).permit(:title, :body, :description, :published_at, :tag_list, :keyword_list, :images_attributes => [:image])
+      params.require(:blog_post).permit(:title, :body, :description, :published_at, :tag_list, :keyword_list, :language, :images_attributes => [:image])
     end
 
     def find_blog_post!

--- a/app/helpers/blog_post_helper.rb
+++ b/app/helpers/blog_post_helper.rb
@@ -12,7 +12,7 @@ module BlogPostHelper
   end
 
   def languages_for_select
-    ["en", "af", "ar", "az", "bg", "bn", "bs", "ca", "cs", "cy", "da", "de", "de-AT", "de-CH", "el", "en-AU", "en-CA", "en-GB", "en-IE", "en-IN", "en-NZ", "en-US", "en-ZA", "eo", "es", "es-419", "es-AR", "es-CL", "es-CO", "es-CR", "es-EC", "es-MX", "es-PA", "es-PE", "es-US", "es-VE", "et", "eu", "fa", "fi", "fr", "fr-CA", "fr-CH", "gl", "he", "hi", "hi-IN", "hr", "hu", "id", "is", "it", "it-CH", "ja", "km", "kn", "ko", "lo", "lt", "lv", "mk", "mn", "ms", "nb", "ne", "nl", "nn", "or", "pl", "pt", "pt-BR", "rm", "ro", "ru", "sk", "sl", "sr", "sv", "sw", "ta", "th", "tl", "tr", "uk", "ur", "uz", "vi", "wo", "zh-CN", "zh-HK", "zh-TW", "zh-YUE"]
+    ["en", "ro", "af", "ar", "az", "bg", "bn", "bs", "ca", "cs", "cy", "da", "de", "de-AT", "de-CH", "el", "en-AU", "en-CA", "en-GB", "en-IE", "en-IN", "en-NZ", "en-US", "en-ZA", "eo", "es", "es-419", "es-AR", "es-CL", "es-CO", "es-CR", "es-EC", "es-MX", "es-PA", "es-PE", "es-US", "es-VE", "et", "eu", "fa", "fi", "fr", "fr-CA", "fr-CH", "gl", "he", "hi", "hi-IN", "hr", "hu", "id", "is", "it", "it-CH", "ja", "km", "kn", "ko", "lo", "lt", "lv", "mk", "mn", "ms", "nb", "ne", "nl", "nn", "or", "pl", "pt", "pt-BR", "rm", "ru", "sk", "sl", "sr", "sv", "sw", "ta", "th", "tl", "tr", "uk", "ur", "uz", "vi", "wo", "zh-CN", "zh-HK", "zh-TW", "zh-YUE"]
   end
 
 end

--- a/app/helpers/blog_post_helper.rb
+++ b/app/helpers/blog_post_helper.rb
@@ -1,7 +1,9 @@
 require 'blog_markdown'
+require 'blog_languages'
 
 module BlogPostHelper
   include BlogMarkdown
+  include BlogLanguages
 
   def blog_post_tags(post)
     raw post.tag_list.map { |tag| link_to(tag, filter_posts_path(tag)) }.join(", ")
@@ -9,10 +11,6 @@ module BlogPostHelper
 
   def strip_tags_for_seo(text)
     strip_tags(text).strip
-  end
-
-  def languages_for_select
-    ["en", "ro", "af", "ar", "az", "bg", "bn", "bs", "ca", "cs", "cy", "da", "de", "de-AT", "de-CH", "el", "en-AU", "en-CA", "en-GB", "en-IE", "en-IN", "en-NZ", "en-US", "en-ZA", "eo", "es", "es-419", "es-AR", "es-CL", "es-CO", "es-CR", "es-EC", "es-MX", "es-PA", "es-PE", "es-US", "es-VE", "et", "eu", "fa", "fi", "fr", "fr-CA", "fr-CH", "gl", "he", "hi", "hi-IN", "hr", "hu", "id", "is", "it", "it-CH", "ja", "km", "kn", "ko", "lo", "lt", "lv", "mk", "mn", "ms", "nb", "ne", "nl", "nn", "or", "pl", "pt", "pt-BR", "rm", "ru", "sk", "sl", "sr", "sv", "sw", "ta", "th", "tl", "tr", "uk", "ur", "uz", "vi", "wo", "zh-CN", "zh-HK", "zh-TW", "zh-YUE"]
   end
 
 end

--- a/app/helpers/blog_post_helper.rb
+++ b/app/helpers/blog_post_helper.rb
@@ -11,4 +11,8 @@ module BlogPostHelper
     strip_tags(text).strip
   end
 
+  def languages_for_select
+    ["en", "af", "ar", "az", "bg", "bn", "bs", "ca", "cs", "cy", "da", "de", "de-AT", "de-CH", "el", "en-AU", "en-CA", "en-GB", "en-IE", "en-IN", "en-NZ", "en-US", "en-ZA", "eo", "es", "es-419", "es-AR", "es-CL", "es-CO", "es-CR", "es-EC", "es-MX", "es-PA", "es-PE", "es-US", "es-VE", "et", "eu", "fa", "fi", "fr", "fr-CA", "fr-CH", "gl", "he", "hi", "hi-IN", "hr", "hu", "id", "is", "it", "it-CH", "ja", "km", "kn", "ko", "lo", "lt", "lv", "mk", "mn", "ms", "nb", "ne", "nl", "nn", "or", "pl", "pt", "pt-BR", "rm", "ro", "ru", "sk", "sl", "sr", "sv", "sw", "ta", "th", "tl", "tr", "uk", "ur", "uz", "vi", "wo", "zh-CN", "zh-HK", "zh-TW", "zh-YUE"]
+  end
+
 end

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -11,7 +11,7 @@ class BlogPost < ActiveRecord::Base
   validates :body, :presence => true
   validates :description, :presence => true, :if => :published?
 
-  default_scope { where("published_at IS NOT NULL").order("published_at DESC") }
+  default_scope { where("published_at IS NOT NULL").where(:language => I18n.locale).order("published_at DESC") }
 
   def to_param
     title_to_slug

--- a/app/views/admin/blog_posts/_form.html.erb
+++ b/app/views/admin/blog_posts/_form.html.erb
@@ -44,7 +44,7 @@
     <% end %>
   </table>
 <% end %>
-<%= f.select :language, languages_for_select, {}, :class => "form-control", :id => "simple-blog-post-form-language", :value => blog_post.language %>
+<%= f.select :language, languages_for_select, {:prompt => ["English", "en"]}, :class => "form-control", :id => "simple-blog-post-form-language", :value => blog_post.language %>
 <%= f.fields_for :images, blog_post.images.build do |i| %>
   <div class="form-group">
     <%= i.label :image %>

--- a/app/views/admin/blog_posts/_form.html.erb
+++ b/app/views/admin/blog_posts/_form.html.erb
@@ -44,6 +44,7 @@
     <% end %>
   </table>
 <% end %>
+<%= f.select :language, languages_for_select, {}, :class => "form-control", :id => "simple-blog-post-form-language", :value => blog_post.language %>
 <%= f.fields_for :images, blog_post.images.build do |i| %>
   <div class="form-group">
     <%= i.label :image %>

--- a/app/views/admin/blog_posts/index.html.erb
+++ b/app/views/admin/blog_posts/index.html.erb
@@ -35,6 +35,9 @@
               <td class="simple-blog-post-published">
                 <%= post.published? %>
               </td>
+              <td class="simple-blog-post-language">
+                <%= post.language %>
+              </td>
               <td class="simple-blog-post-delete">
                 <%= link_to t('.delete'), admin_blog_post_path(post.id), :method => :delete, :data => { confirm: t('.are_you_sure') } %>
               </td>

--- a/app/views/admin/blog_posts/index.html.erb
+++ b/app/views/admin/blog_posts/index.html.erb
@@ -37,7 +37,7 @@
                 <%= post.published? %>
               </td>
               <td class="simple-blog-post-language">
-                <%= post.language %>
+                <%= language_full_name(post.language) %>
               </td>
               <td class="simple-blog-post-delete">
                 <%= link_to t('.delete'), admin_blog_post_path(post.id), :method => :delete, :data => { confirm: t('.are_you_sure') } %>

--- a/app/views/admin/blog_posts/index.html.erb
+++ b/app/views/admin/blog_posts/index.html.erb
@@ -19,6 +19,7 @@
             <th><%= t('.blog_post_tags') %></th>
             <th><%= t('.blog_post_keywords') %></th>
             <th><%= t('.blog_post_published') %></th>
+            <th><%= t('.blog_post_language')%></th>
             <th><%= t('.blog_post_delete') %></th>
           </tr>
           <% @blog_posts.each do |post| %>

--- a/db/migrate/20150115103932_add_language_to_blog_post.rb
+++ b/db/migrate/20150115103932_add_language_to_blog_post.rb
@@ -1,0 +1,5 @@
+class AddLanguageToBlogPost < ActiveRecord::Migration
+  def change
+    add_column :blog_posts, :language, :string
+  end
+end

--- a/lib/blog_languages.rb
+++ b/lib/blog_languages.rb
@@ -1,0 +1,13 @@
+module BlogLanguages
+
+  LANGUAGES = {"af" => "Afrikaans", "ar" => "Arabic", "az" => "Azerbaijani", "bg" => "Bulgarian", "bn" => "Bengali", "bs" => "Bosnian", "ca" => "Catalan", "cs" => "Czech", "cy" => "Welsh", "da" => "Danish", "de" => "German", "de-AT" => "German-Austria", "de-CH" => "German-Switzerland", "el" => "Greek", "en" => "English", "en-AU" => "English-Australia", "en-CA" => "English-Canada", "en-GB" => "English-United Kingdom", "en-IE" => "English-Ireland", "en-NZ" => "English-New Zealand", "en-US" => "English-United States", "en-ZA" => "English-South Africa", "eo" => "Esperanto", "es" => "Spanish", "es-419" => "Spanish-Latin America", "es-AR" => "Spanish-Argentina", "es-CL" => "Spanish-Chile", "es-CO" => "Spanish-Colombia", "es-CR" => "Spanish-Costa Rica", "es-EC" => "Spanish-Ecuador", "es-MX" => "Spanish-Mexico", "es-PA" => "Spanish-Panama", "es-PE" => "Spanish-Peru", "es-US" => "Spanish-United States", "es-VE" => "Spanish-Venezuela", "et" => "Estonia", "eu" => "", "fa" => "Persian", "fi" => "Finnish", "fr" => "French", "fr-CA" => "French-Canada", "fr-CH" => "French-Switzerland", "gl" => "Galician", "he" => "Hebrew", "hi" => "Hindi", "hi-IN" => "Hindi-India", "hr" => "Croatian", "hu" => "Hungarian", "id" => "Indonesian", "is" => "Icelandic", "it" => "Italian", "it-CH" => "Italian-Switzerland", "ja" => "Japanese", "km" => "Khmer", "kn" => "Kannada", "ko" => "Korean", "lo" => "Lao", "lt" => "Lithuanian", "lv" => "Latvian", "mk" => "Macedonian", "mn" => "Mongolian", "ms" => "Nalay", "nb" => "Norwegian Bokmal", "ne" => "Nepali", "nl" => "Dutch", "nn" => "Norwegian Nynorsk", "or" => "Oriya", "pl" => "Polish", "pt" => "Portuguese", "pt-BR" => "Portuguese-Brazil", "rm" => "Romansh", "ru" => "Russian", "ro" => "Romanian", "sk" => "Saraiki", "sl" => "Slovene", "sr" => "Serbian", "sv" => "Swedish", "sw" => "Swahili", "ta" => "Tamil", "th" => "Thai", "tl" => "Tagalog", "tr" => "Turkish", "uk" => "Ukrainian", "ur" => "Urdu", "uz" => "Uzbek", "vi" => "Vietnamese", "wo" => "Wolof", "zh-CN" => "Chinese-China", "zh-HK" => "Chinese-Hong Kong", "zh-TW" => "Chinese-Taiwan", "zh-YUE" => "Cantonese"}
+
+  def languages_for_select
+    LANGUAGES.collect { |country_code, country_translation| [country_translation, country_code]  }
+  end
+
+  def language_full_name(language_code)
+    LANGUAGES[language_code]
+  end
+
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141006100218) do
+ActiveRecord::Schema.define(version: 20150115103932) do
 
   create_table "blog_images", force: true do |t|
     t.integer "blog_post_id"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20141006100218) do
     t.string   "slug"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "language"
   end
 
   create_table "taggings", force: true do |t|

--- a/spec/factories/blog_posts.rb
+++ b/spec/factories/blog_posts.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
     body "Even more awesome post body"
     description "The most awesome post description"
     published_at 1.week.ago
+    language "en"
   end
 end

--- a/spec/features/create_posts_spec.rb
+++ b/spec/features/create_posts_spec.rb
@@ -6,7 +6,7 @@ feature 'Create posts' do
     expect(current_path).to match "edit"
   end
 
-  scenario 'creating a blog with another language then english' do
+  scenario 'creating a blog with a different language then english' do
     create_a_blog_post(:language => "ro")
     visit admin_blog_posts_path
     expect(page).to have_content("ro")

--- a/spec/features/create_posts_spec.rb
+++ b/spec/features/create_posts_spec.rb
@@ -6,6 +6,12 @@ feature 'Create posts' do
     expect(current_path).to match "edit"
   end
 
+  scenario 'creating a blog with another language then english' do
+    create_a_blog_post(:language => "ro")
+    visit admin_blog_posts_path
+    expect(page).to have_content("ro")
+  end
+
   scenario 'user can create new posts' do
     create_a_blog_post
     success_message = 'Post was succesfully created.'

--- a/spec/features/create_posts_spec.rb
+++ b/spec/features/create_posts_spec.rb
@@ -7,9 +7,9 @@ feature 'Create posts' do
   end
 
   scenario 'creating a blog with a different language then english' do
-    create_a_blog_post(:language => "ro")
+    create_a_blog_post(:language => "Romanian")
     visit admin_blog_posts_path
-    expect(page).to have_content("ro")
+    expect(page).to have_content("Romanian")
   end
 
   scenario 'user can create new posts' do

--- a/spec/features/list_posts_spec.rb
+++ b/spec/features/list_posts_spec.rb
@@ -15,6 +15,7 @@ feature 'List posts' do
     visit blog_posts_path
     expect(page).to have_content('Romanian Blog Post')
     expect(page).not_to have_content('Blog Post Title')
+    I18n.locale = 'en'
   end
 
   scenario "should only display the post's descsription" do

--- a/spec/features/list_posts_spec.rb
+++ b/spec/features/list_posts_spec.rb
@@ -9,6 +9,14 @@ feature 'List posts' do
                        :keywords => 'first_keyword, second_keyword')
   end
 
+  scenario 'should only show articles of the current locale' do
+    create_a_blog_post(:title => 'Romanian blog post', :language => 'ro')
+    I18n.locale = 'ro'
+    visit blog_posts_path
+    expect(page).to have_content('Romanian Blog Post')
+    expect(page).not_to have_content('Blog Post Title')
+  end
+
   scenario "should only display the post's descsription" do
     visit blog_posts_path
     expect(page).to have_content('Blog post description')

--- a/spec/features/list_posts_spec.rb
+++ b/spec/features/list_posts_spec.rb
@@ -10,7 +10,7 @@ feature 'List posts' do
   end
 
   scenario 'should only show articles of the current locale' do
-    create_a_blog_post(:title => 'Romanian blog post', :language => 'ro')
+    create_a_blog_post(:title => 'Romanian blog post', :language => 'Romanian')
     I18n.locale = 'ro'
     visit blog_posts_path
     expect(page).to have_content('Romanian Blog Post')

--- a/spec/lib/blog_languages_spec.rb
+++ b/spec/lib/blog_languages_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'blog_languages'
+
+describe BlogLanguages, :type => :model do
+  class BlogModel
+    include BlogLanguages
+  end
+
+  before :each do
+    @blog_model = BlogModel.new
+  end
+
+  describe "#languages_for_select" do
+
+    it "returns a list containing arrays that have the language name and language translation" do
+      expect(@blog_model.languages_for_select).to include(["English", "en"])
+    end
+
+  end
+
+  describe "#language_full_name" do
+
+    it "returns the language translation from the language code" do
+      expect(@blog_model.language_full_name("en")).to eq("English")
+    end
+
+  end
+
+
+end

--- a/spec/models/blog_post_spec.rb
+++ b/spec/models/blog_post_spec.rb
@@ -33,6 +33,10 @@ describe BlogPost, :type => :model do
   end
 
   describe "default_scope" do
+    before :each do
+      allow(I18n).to receive(:locale).and_return("en")
+    end
+
     it "finds all the published records" do
       published = create(:blog_post)
       create(:blog_post, :published_at => nil) # unpublished
@@ -43,6 +47,19 @@ describe BlogPost, :type => :model do
       published1 = create(:blog_post, :published_at => 2.days.ago)
       published2 = create(:blog_post, :published_at => Time.now)
       expect(BlogPost.all).to eq([published2, published1])
+    end
+
+    context "language" do
+      let!(:english_post) { create(:blog_post, :language => "en") }
+      let!(:romanian_post) { create(:blog_post, :language => "ro") }
+
+      it "retuns the current language blog_posts" do
+        expect(BlogPost.all).to eq([english_post])
+      end
+
+      it "does not return other language blog_posts" do
+        expect(BlogPost.all).not_to include(romanian_post)
+      end
     end
   end
 
@@ -132,6 +149,16 @@ describe BlogPost, :type => :model do
     it "searches for blog posts with the specified options" do
       expect(blog_post).to receive(:find_by!).with(options)
       BlogPost.unscoped_find_by!(options)
+    end
+  end
+
+  describe "#set_slug" do
+    let(:title) { "blog post title" }
+    let(:blog_post) { create(:blog_post, :title => title) }
+
+    it "creates the slug from the title" do
+      expected_slug = title.parameterize
+      expect(blog_post.slug).to eq(expected_slug)
     end
   end
 

--- a/spec/models/blog_post_spec.rb
+++ b/spec/models/blog_post_spec.rb
@@ -32,7 +32,7 @@ describe BlogPost, :type => :model do
     end
   end
 
-   describe "default_scope" do
+  describe "default_scope" do
     it "finds all the published records" do
       published = create(:blog_post)
       create(:blog_post, :published_at => nil) # unpublished

--- a/spec/models/blog_post_spec.rb
+++ b/spec/models/blog_post_spec.rb
@@ -32,11 +32,7 @@ describe BlogPost, :type => :model do
     end
   end
 
-  describe "default_scope" do
-    before :each do
-      allow(I18n).to receive(:locale).and_return("en")
-    end
-
+   describe "default_scope" do
     it "finds all the published records" do
       published = create(:blog_post)
       create(:blog_post, :published_at => nil) # unpublished
@@ -49,15 +45,15 @@ describe BlogPost, :type => :model do
       expect(BlogPost.all).to eq([published2, published1])
     end
 
-    context "language" do
+    context "default locale" do
       let!(:english_post) { create(:blog_post, :language => "en") }
       let!(:romanian_post) { create(:blog_post, :language => "ro") }
 
-      it "retuns the current language blog_posts" do
+      it "retuns the current locale blog_posts" do
         expect(BlogPost.all).to eq([english_post])
       end
 
-      it "does not return other language blog_posts" do
+      it "does not return other locale blog_posts" do
         expect(BlogPost.all).not_to include(romanian_post)
       end
     end
@@ -149,16 +145,6 @@ describe BlogPost, :type => :model do
     it "searches for blog posts with the specified options" do
       expect(blog_post).to receive(:find_by!).with(options)
       BlogPost.unscoped_find_by!(options)
-    end
-  end
-
-  describe "#set_slug" do
-    let(:title) { "blog post title" }
-    let(:blog_post) { create(:blog_post, :title => title) }
-
-    it "creates the slug from the title" do
-      expected_slug = title.parameterize
-      expect(blog_post.slug).to eq(expected_slug)
     end
   end
 

--- a/spec/support/common_helpers.rb
+++ b/spec/support/common_helpers.rb
@@ -8,7 +8,7 @@ def create_a_blog_post(options={})
   end
   fill_in 'simple-blog-post-form-tag-list', :with => options[:tags] || 'first_tag, second_tag'
   fill_in 'simple-blog-post-form-keyword-list', :with => options[:keywords] || 'first_keyword, second_keyword'
-  select options[:language] || 'en', :from => 'simple-blog-post-form-language'
+  select options[:language] || 'English', :from => 'simple-blog-post-form-language'
   attach_image('simple-blog-post-form-image', options[:image] || 'test.png')
   click_button 'Create post'
 end

--- a/spec/support/common_helpers.rb
+++ b/spec/support/common_helpers.rb
@@ -8,6 +8,7 @@ def create_a_blog_post(options={})
   end
   fill_in 'simple-blog-post-form-tag-list', :with => options[:tags] || 'first_tag, second_tag'
   fill_in 'simple-blog-post-form-keyword-list', :with => options[:keywords] || 'first_keyword, second_keyword'
+  select options[:language] || 'en', :from => 'simple-blog-post-form-language'
   attach_image('simple-blog-post-form-image', options[:image] || 'test.png')
   click_button 'Create post'
 end


### PR DESCRIPTION
Add language attribute to blog posts. Create two integration tests. One allows you to create a blog post with a set language. The other test is for the default filter. Only article that have the language = I18n.locale will be displayed. Admin will still see all the articles. 

Issue for this ticket: https://github.com/mixandgo/simple_blog/issues/63